### PR TITLE
feat: add education and skills sections to CV component

### DIFF
--- a/src/app/features/cv/components/education-section/education-section.component.html
+++ b/src/app/features/cv/components/education-section/education-section.component.html
@@ -1,0 +1,41 @@
+<div class="education-container">
+  <section class="education">
+    <div class="section-header">
+      <h2>Education History</h2>
+    </div>
+    <div class="education-grid">
+      <mat-card *ngFor="let edu of education()" class="education-card">
+        <mat-card-content>
+          <h3>{{ edu.degree }}</h3>
+          <p>{{ edu.institution }}</p>
+          <mat-chip-set>
+            <mat-chip *ngFor="let keyword of edu.keywords">{{
+              keyword
+            }}</mat-chip>
+          </mat-chip-set>
+        </mat-card-content>
+      </mat-card>
+    </div>
+  </section>
+
+  <section class="certifications" *ngIf="certifications()?.length">
+    <div class="section-header">
+      <h2>Certifications</h2>
+    </div>
+    <div class="certifications-grid">
+      <mat-card
+        *ngFor="let cert of certifications()"
+        class="certification-card"
+      >
+        <mat-card-content>
+          <h3>{{ cert.name }}</h3>
+          <mat-chip-set>
+            <mat-chip *ngFor="let keyword of cert.keywords">{{
+              keyword
+            }}</mat-chip>
+          </mat-chip-set>
+        </mat-card-content>
+      </mat-card>
+    </div>
+  </section>
+</div>

--- a/src/app/features/cv/components/education-section/education-section.component.scss
+++ b/src/app/features/cv/components/education-section/education-section.component.scss
@@ -1,0 +1,42 @@
+.education-container {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  padding: 1rem;
+
+  .section-header {
+    margin-bottom: 2rem;
+
+    h2 {
+      color: var(--gray-900);
+      font-size: 1.5rem;
+      font-weight: 500;
+      margin: 0;
+    }
+  }
+
+  .education-grid,
+  .certifications-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+
+    mat-card-content {
+      h3 {
+        color: var(--gray-800);
+        margin: 0 0 0.5rem;
+      }
+
+      p {
+        color: var(--gray-700);
+        margin: 0 0 1rem;
+      }
+
+      mat-chip-set {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+    }
+  }
+}

--- a/src/app/features/cv/components/education-section/education-section.component.spec.ts
+++ b/src/app/features/cv/components/education-section/education-section.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EducationSectionComponent } from './education-section.component';
+
+describe('EducationSectionComponent', () => {
+  let component: EducationSectionComponent;
+  let fixture: ComponentFixture<EducationSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EducationSectionComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(EducationSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/cv/components/education-section/education-section.component.ts
+++ b/src/app/features/cv/components/education-section/education-section.component.ts
@@ -1,0 +1,22 @@
+import { Component, computed, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { Store } from '@ngrx/store';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { CvState } from '../../../../state/cv/cv.state';
+import { selectEducation, selectCertifications } from '../../../../state';
+
+@Component({
+  selector: 'app-education-section',
+  standalone: true,
+  imports: [CommonModule, MatCardModule, MatChipsModule],
+  templateUrl: './education-section.component.html',
+  styleUrls: ['./education-section.component.scss'],
+})
+export class EducationSectionComponent {
+  private readonly store = inject(Store<CvState>);
+
+  education = toSignal(this.store.select(selectEducation));
+  certifications = toSignal(this.store.select(selectCertifications));
+}

--- a/src/app/features/cv/components/skills-section/skills-section.component.html
+++ b/src/app/features/cv/components/skills-section/skills-section.component.html
@@ -1,0 +1,32 @@
+<div class="skills-container">
+  <div class="section-header">
+    <h2>Skills</h2>
+    <mat-button-toggle-group
+      [value]="viewMode()"
+      (change)="toggleViewMode($event.value)"
+    >
+      <mat-button-toggle value="grid">
+        <mat-icon>grid_view</mat-icon>
+      </mat-button-toggle>
+      <mat-button-toggle value="list">
+        <mat-icon>view_list</mat-icon>
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
+  <div class="skills-grid" [class.list-view]="viewMode() === 'list'">
+    <mat-card
+      *ngFor="let category of skills()?.categories"
+      class="skill-category"
+    >
+      <mat-card-header>
+        <mat-card-title>{{ category.name }}</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <mat-chip-set>
+          <mat-chip *ngFor="let skill of category.items">{{ skill }}</mat-chip>
+        </mat-chip-set>
+      </mat-card-content>
+    </mat-card>
+  </div>
+</div>

--- a/src/app/features/cv/components/skills-section/skills-section.component.scss
+++ b/src/app/features/cv/components/skills-section/skills-section.component.scss
@@ -1,0 +1,39 @@
+.skills-container {
+  padding: 1rem;
+
+  .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2rem;
+
+    h2 {
+      color: var(--gray-900);
+      font-size: 1.5rem;
+      font-weight: 500;
+      margin: 0;
+    }
+  }
+
+  .skills-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+
+    &.list-view {
+      grid-template-columns: 1fr;
+    }
+
+    .skill-category {
+      mat-card-content {
+        padding-top: 1rem;
+      }
+
+      mat-chip-set {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+    }
+  }
+}

--- a/src/app/features/cv/components/skills-section/skills-section.component.spec.ts
+++ b/src/app/features/cv/components/skills-section/skills-section.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SkillsSectionComponent } from './skills-section.component';
+
+describe('SkillsSectionComponent', () => {
+  let component: SkillsSectionComponent;
+  let fixture: ComponentFixture<SkillsSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SkillsSectionComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SkillsSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/cv/components/skills-section/skills-section.component.ts
+++ b/src/app/features/cv/components/skills-section/skills-section.component.ts
@@ -1,0 +1,35 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatIconModule } from '@angular/material/icon';
+import { Store } from '@ngrx/store';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { CvState } from '../../../../state/cv/cv.state';
+import { selectSkills } from '../../../../state';
+
+type ViewMode = 'grid' | 'list';
+
+@Component({
+  selector: 'app-skills-section',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatChipsModule,
+    MatButtonToggleModule,
+    MatIconModule,
+  ],
+  templateUrl: './skills-section.component.html',
+  styleUrls: ['./skills-section.component.scss'],
+})
+export class SkillsSectionComponent {
+  private readonly store = inject(Store<CvState>);
+  skills = toSignal(this.store.select(selectSkills));
+  viewMode = signal<ViewMode>('grid');
+
+  toggleViewMode(mode: ViewMode) {
+    this.viewMode.set(mode);
+  }
+}

--- a/src/app/features/cv/cv.component.html
+++ b/src/app/features/cv/cv.component.html
@@ -1,4 +1,6 @@
-<div class="cv-content">
+<div class="cv-container">
   <app-basics-section></app-basics-section>
   <app-experience-section></app-experience-section>
+  <app-education-section></app-education-section>
+  <app-skills-section></app-skills-section>
 </div>

--- a/src/app/features/cv/cv.component.scss
+++ b/src/app/features/cv/cv.component.scss
@@ -3,3 +3,25 @@
   flex-direction: column;
   gap: 2rem;
 }
+
+.cv-container {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+
+  nav {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background: var(--background-color);
+  }
+
+  mat-tab-nav-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+}

--- a/src/app/features/cv/cv.component.ts
+++ b/src/app/features/cv/cv.component.ts
@@ -1,14 +1,22 @@
 import { Component, inject, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { Store } from '@ngrx/store';
 import { CvPageActions } from '../../state';
 import { ExperienceSectionComponent } from './components/experience-section/experience-section.component';
 import { BasicsSectionComponent } from './components/basics-section/basics-section.component';
-import { CommonModule } from '@angular/common';
+import { EducationSectionComponent } from './components/education-section/education-section.component';
+import { SkillsSectionComponent } from './components/skills-section/skills-section.component';
 
 @Component({
   selector: 'app-cv',
   standalone: true,
-  imports: [CommonModule, BasicsSectionComponent, ExperienceSectionComponent],
+  imports: [
+    CommonModule,
+    BasicsSectionComponent,
+    ExperienceSectionComponent,
+    EducationSectionComponent,
+    SkillsSectionComponent,
+  ],
   templateUrl: './cv.component.html',
   styleUrls: ['./cv.component.scss'],
 })

--- a/src/app/models/cv.model.ts
+++ b/src/app/models/cv.model.ts
@@ -18,12 +18,14 @@ export interface CvData {
     keywords: string[];
   }[];
   skills: {
-    categories: {
-      name: string;
-      items: string[];
-      keywords: string[];
-    }[];
+    categories: SkillCategory[];
   };
+}
+
+export interface SkillCategory {
+  name: string;
+  items: string[];
+  keywords: string[];
 }
 
 export interface CompanyExperience {

--- a/src/app/state/cv/cv.selectors.ts
+++ b/src/app/state/cv/cv.selectors.ts
@@ -32,3 +32,18 @@ export const selectCompanies = createSelector(
     });
   }
 );
+
+export const selectEducation = createSelector(
+  selectCvState,
+  (state: CvState) => state.education
+);
+
+export const selectCertifications = createSelector(
+  selectCvState,
+  (state: CvState) => state.certifications
+);
+
+export const selectSkills = createSelector(
+  selectCvState,
+  (state: CvState) => state.skills
+);

--- a/src/app/state/index.ts
+++ b/src/app/state/index.ts
@@ -12,3 +12,6 @@ export const selectBasics = Selectors.selectBasics;
 export const selectCompanies = Selectors.selectCompanies;
 export const selectError = Selectors.selectError;
 export const selectLoading = Selectors.selectLoading;
+export const selectEducation = Selectors.selectEducation;
+export const selectSkills = Selectors.selectSkills;
+export const selectCertifications = Selectors.selectCertifications;


### PR DESCRIPTION
This pull request introduces new components for the education and skills sections in the CV feature, along with their corresponding styles, tests, and state management. Here are the most important changes:

### New Components and Templates:
* [`src/app/features/cv/components/education-section/education-section.component.html`](diffhunk://#diff-11cb91fc3058e9d295297385cb0706928f084f333396236d73897fbabe97af77R1-R41): Added a new education section template to display education history and certifications.
* [`src/app/features/cv/components/skills-section/skills-section.component.html`](diffhunk://#diff-f887f1a19449c02412e4ef4c9f96e06d87b68ce7119124e3e71fb7e59c4f1ea8R1-R32): Added a new skills section template to display skills in grid or list view.

### Styles:
* [`src/app/features/cv/components/education-section/education-section.component.scss`](diffhunk://#diff-52c28194a841d264fdf125a3e1a848576c95f24f23f2955ba6f5462cc64c624aR1-R42): Added styles for the education section, including layout and typography.
* [`src/app/features/cv/components/skills-section/skills-section.component.scss`](diffhunk://#diff-f731418408c461e2271d9969690e70431873046090db062407f884a56afa4280R1-R39): Added styles for the skills section, including layout and responsive design.

### Component Logic:
* [`src/app/features/cv/components/education-section/education-section.component.ts`](diffhunk://#diff-16f2165f1dcbfb7a0cc56929baf814ffa46c28c1f4809738d5810ae57396437dR1-R22): Implemented the logic for the education section, including state management and data binding.
* [`src/app/features/cv/components/skills-section/skills-section.component.ts`](diffhunk://#diff-ae735f301fe1a67c14ffc3dd9c5c47fd247ae4264d4aa32e3763fde538455f26R1-R35): Implemented the logic for the skills section, including state management and view mode toggling.

### State Management:
* [`src/app/state/cv/cv.selectors.ts`](diffhunk://#diff-41aa32f7d5b3a53ece0fefcc66bc33b0fea2701f174c3fc7a40372a8a97b633dR35-R49): Added selectors for education, certifications, and skills.
* [`src/app/state/index.ts`](diffhunk://#diff-0b662c7f0fa487022471c6bd586f6c48468c60961a9fe92595aa911a07441334R15-R17): Exported the new selectors for education, certifications, and skills.